### PR TITLE
feature(db-operations-go):  create CleanTables function

### DIFF
--- a/db/sqlc/db_operations.go
+++ b/db/sqlc/db_operations.go
@@ -26,3 +26,13 @@ func (q *Queries) CleanTable(ctx context.Context, tableName string) error {
 	_, err := q.db.ExecContext(ctx, fmt.Sprintf(cleanTable, tableName, tableName))
 	return err
 }
+
+func (q *Queries) CleanTables(ctx context.Context, tablesNames []string) []error {
+	var errors []error
+	for _, table := range tablesNames {
+		if err := q.CleanTable(ctx, table); err != nil {
+			errors = append(errors, fmt.Errorf("failed to clean table %s: %w", table, err))
+		}
+	}
+	return errors
+}


### PR DESCRIPTION
takes a slice of table names, and returns a slice of errors that may occur when deleting tables